### PR TITLE
feat: add git provider interface with gitlab support

### DIFF
--- a/apps/open-swe/src/routes/app.ts
+++ b/apps/open-swe/src/routes/app.ts
@@ -1,6 +1,13 @@
 import { Hono } from "hono";
-import { issueWebhookHandler } from "./github/issue-webhook.js";
+import { issueWebhookHandler as githubIssueWebhookHandler } from "./git/github/issue-webhook.js";
+import { issueWebhookHandler as gitlabIssueWebhookHandler } from "./git/gitlab/issue-webhook.js";
 
 export const app = new Hono();
 
-app.post("/webhooks/github", issueWebhookHandler);
+const provider = process.env.GIT_PROVIDER ?? "github";
+
+if (provider === "gitlab") {
+  app.post("/webhooks/gitlab", gitlabIssueWebhookHandler);
+} else {
+  app.post("/webhooks/github", githubIssueWebhookHandler);
+}

--- a/apps/open-swe/src/routes/git/github/issue-webhook.ts
+++ b/apps/open-swe/src/routes/git/github/issue-webhook.ts
@@ -1,10 +1,10 @@
 import { v4 as uuidv4 } from "uuid";
 import { Context } from "hono";
 import { BlankEnv, BlankInput } from "hono/types";
-import { createLogger, LogLevel } from "../../utils/logger.js";
-import { GitHubApp } from "../../utils/github-app.js";
+import { createLogger, LogLevel } from "../../../utils/logger.js";
+import { GitHubApp } from "../../../utils/github-app.js";
 import { Webhooks } from "@octokit/webhooks";
-import { createLangGraphClient } from "../../utils/langgraph-client.js";
+import { createLangGraphClient } from "../../../utils/langgraph-client.js";
 import {
   GITHUB_INSTALLATION_ID,
   GITHUB_INSTALLATION_NAME,
@@ -21,11 +21,11 @@ import {
   getOpenSWELabel,
   getOpenSWEMaxLabel,
   getOpenSWEMaxAutoAcceptLabel,
-} from "../../utils/github/label.js";
+} from "../../../utils/github/label.js";
 import { ManagerGraphUpdate } from "@open-swe/shared/open-swe/manager/types";
-import { RequestSource } from "../../constants.js";
+import { RequestSource } from "../../../constants.js";
 import { isAllowedUser } from "@open-swe/shared/github/allowed-users";
-import { getOpenSweAppUrl } from "../../utils/url-helpers.js";
+import { getOpenSweAppUrl } from "../../../utils/url-helpers.js";
 import { StreamMode } from "@langchain/langgraph-sdk";
 
 const logger = createLogger(LogLevel.INFO, "GitHubIssueWebhook");

--- a/apps/open-swe/src/routes/git/gitlab/issue-webhook.ts
+++ b/apps/open-swe/src/routes/git/gitlab/issue-webhook.ts
@@ -1,0 +1,59 @@
+import { Context } from "hono";
+import { BlankEnv, BlankInput } from "hono/types";
+import { createLogger, LogLevel } from "../../../utils/logger.js";
+import {
+  getOpenSWELabel,
+  getOpenSWEAutoAcceptLabel,
+  getOpenSWEMaxLabel,
+  getOpenSWEMaxAutoAcceptLabel,
+} from "../../../utils/github/label.js";
+import { gitlabProvider } from "../../../utils/gitlab/provider.js";
+
+const logger = createLogger(LogLevel.INFO, "GitLabIssueWebhook");
+
+const GITLAB_TOKEN = process.env.GITLAB_TOKEN;
+
+export async function issueWebhookHandler(
+  c: Context<BlankEnv, "/webhooks/gitlab", BlankInput>,
+) {
+  if (!GITLAB_TOKEN) {
+    logger.error("GITLAB_TOKEN not configured");
+    return c.json({ error: "Missing token" }, 400);
+  }
+
+  const payload = await c.req.json();
+  const addedLabels =
+    payload.changes?.labels?.current?.map((l: any) => l.title) ?? [];
+  const previousLabels =
+    payload.changes?.labels?.previous?.map((l: any) => l.title) ?? [];
+  const newLabels = addedLabels.filter(
+    (l: string) => !previousLabels.includes(l),
+  );
+
+  const validLabels = [
+    getOpenSWELabel(),
+    getOpenSWEAutoAcceptLabel(),
+    getOpenSWEMaxLabel(),
+    getOpenSWEMaxAutoAcceptLabel(),
+  ];
+
+  if (!newLabels.some((l: string) => validLabels.includes(l))) {
+    return c.json({ skipped: true });
+  }
+
+  const issue = payload.object_attributes;
+  const project = payload.project;
+  const [owner, repo] = project.path_with_namespace.split("/");
+  const issueNumber = issue.iid;
+
+  await gitlabProvider.createIssueComment({
+    owner,
+    repo,
+    issueNumber,
+    body: "🤖 Open SWE has been triggered for this issue. Processing...",
+    token: GITLAB_TOKEN,
+  });
+
+  logger.info("Processed GitLab issue", { owner, repo, issueNumber });
+  return c.json({ received: true });
+}

--- a/apps/open-swe/src/utils/github/provider.ts
+++ b/apps/open-swe/src/utils/github/provider.ts
@@ -1,0 +1,85 @@
+import {
+  GitProvider,
+  GitIssue,
+  GitIssueComment,
+  GitBranch,
+} from "@open-swe/shared/git/provider";
+import {
+  getIssue as githubGetIssue,
+  updateIssue as githubUpdateIssue,
+  createIssueComment as githubCreateIssueComment,
+  updateIssueComment as githubUpdateIssueComment,
+  getBranch as githubGetBranch,
+} from "./api.js";
+
+export const githubProvider: GitProvider = {
+  getIssue: async ({
+    owner,
+    repo,
+    issueNumber,
+    token,
+  }): Promise<GitIssue | null> =>
+    githubGetIssue({
+      owner,
+      repo,
+      issueNumber,
+      githubInstallationToken: token,
+    }),
+  updateIssue: async ({
+    owner,
+    repo,
+    issueNumber,
+    title,
+    body,
+    token,
+  }): Promise<GitIssue | null> =>
+    githubUpdateIssue({
+      owner,
+      repo,
+      issueNumber,
+      title,
+      body,
+      githubInstallationToken: token,
+    }),
+  createIssueComment: async ({
+    owner,
+    repo,
+    issueNumber,
+    body,
+    token,
+  }): Promise<GitIssueComment | null> =>
+    githubCreateIssueComment({
+      owner,
+      repo,
+      issueNumber,
+      body,
+      githubToken: token,
+    }),
+  updateIssueComment: async ({
+    owner,
+    repo,
+    commentId,
+    body,
+    token,
+    issueNumber,
+  }): Promise<GitIssueComment | null> =>
+    githubUpdateIssueComment({
+      owner,
+      repo,
+      commentId,
+      body,
+      githubInstallationToken: token,
+    }),
+  getBranch: async ({
+    owner,
+    repo,
+    branchName,
+    token,
+  }): Promise<GitBranch | null> =>
+    githubGetBranch({
+      owner,
+      repo,
+      branchName,
+      githubInstallationToken: token,
+    }),
+};

--- a/apps/open-swe/src/utils/gitlab/api.ts
+++ b/apps/open-swe/src/utils/gitlab/api.ts
@@ -1,0 +1,143 @@
+import {
+  GitIssue,
+  GitIssueComment,
+  GitBranch,
+} from "@open-swe/shared/git/provider";
+
+const API_URL = process.env.GITLAB_API_URL || "https://gitlab.com/api/v4";
+
+function projectPath(owner: string, repo: string): string {
+  return encodeURIComponent(`${owner}/${repo}`);
+}
+
+async function gitlabRequest<T>(
+  path: string,
+  token: string,
+  init?: RequestInit,
+): Promise<T | null> {
+  const res = await fetch(`${API_URL}${path}`, {
+    headers: {
+      "PRIVATE-TOKEN": token,
+      "Content-Type": "application/json",
+    },
+    ...init,
+  });
+  if (!res.ok) {
+    return null;
+  }
+  return res.json() as Promise<T>;
+}
+
+export async function getIssue({
+  owner,
+  repo,
+  issueNumber,
+  token,
+}: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  token: string;
+}): Promise<GitIssue | null> {
+  return gitlabRequest<GitIssue>(
+    `/projects/${projectPath(owner, repo)}/issues/${issueNumber}`,
+    token,
+  );
+}
+
+export async function updateIssue({
+  owner,
+  repo,
+  issueNumber,
+  title,
+  body,
+  token,
+}: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  title?: string;
+  body?: string;
+  token: string;
+}): Promise<GitIssue | null> {
+  return gitlabRequest<GitIssue>(
+    `/projects/${projectPath(owner, repo)}/issues/${issueNumber}`,
+    token,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        title,
+        description: body,
+      }),
+    },
+  );
+}
+
+export async function createIssueComment({
+  owner,
+  repo,
+  issueNumber,
+  body,
+  token,
+}: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  body: string;
+  token: string;
+}): Promise<GitIssueComment | null> {
+  return gitlabRequest<GitIssueComment>(
+    `/projects/${projectPath(owner, repo)}/issues/${issueNumber}/notes`,
+    token,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        body,
+      }),
+    },
+  );
+}
+
+export async function updateIssueComment({
+  owner,
+  repo,
+  issueNumber,
+  commentId,
+  body,
+  token,
+}: {
+  owner: string;
+  repo: string;
+  issueNumber: number;
+  commentId: number;
+  body: string;
+  token: string;
+}): Promise<GitIssueComment | null> {
+  return gitlabRequest<GitIssueComment>(
+    `/projects/${projectPath(owner, repo)}/issues/${issueNumber}/notes/${commentId}`,
+    token,
+    {
+      method: "PUT",
+      body: JSON.stringify({
+        body,
+      }),
+    },
+  );
+}
+
+export async function getBranch({
+  owner,
+  repo,
+  branchName,
+  token,
+}: {
+  owner: string;
+  repo: string;
+  branchName: string;
+  token: string;
+}): Promise<GitBranch | null> {
+  return gitlabRequest<GitBranch>(
+    `/projects/${projectPath(owner, repo)}/repository/branches/${branchName}`,
+    token,
+  );
+}

--- a/apps/open-swe/src/utils/gitlab/provider.ts
+++ b/apps/open-swe/src/utils/gitlab/provider.ts
@@ -1,0 +1,28 @@
+import { GitProvider } from "@open-swe/shared/git/provider";
+import {
+  getIssue,
+  updateIssue,
+  createIssueComment,
+  updateIssueComment,
+  getBranch,
+} from "./api.js";
+
+export const gitlabProvider: GitProvider = {
+  getIssue: ({ owner, repo, issueNumber, token }) =>
+    getIssue({ owner, repo, issueNumber, token }),
+  updateIssue: ({ owner, repo, issueNumber, title, body, token }) =>
+    updateIssue({ owner, repo, issueNumber, title, body, token }),
+  createIssueComment: ({ owner, repo, issueNumber, body, token }) =>
+    createIssueComment({ owner, repo, issueNumber, body, token }),
+  updateIssueComment: ({ owner, repo, commentId, body, token, issueNumber }) =>
+    updateIssueComment({
+      owner,
+      repo,
+      commentId,
+      body,
+      token,
+      issueNumber,
+    }),
+  getBranch: ({ owner, repo, branchName, token }) =>
+    getBranch({ owner, repo, branchName, token }),
+};

--- a/packages/shared/src/git/provider.ts
+++ b/packages/shared/src/git/provider.ts
@@ -1,0 +1,53 @@
+export interface GitIssue {
+  number: number;
+  title: string;
+  body: string | null;
+}
+
+export interface GitIssueComment {
+  id: number;
+  body: string;
+}
+
+export interface GitBranch {
+  name: string;
+  sha?: string;
+}
+
+export interface GitProvider {
+  getIssue(params: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    token: string;
+  }): Promise<GitIssue | null>;
+  updateIssue(params: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    title?: string;
+    body?: string;
+    token: string;
+  }): Promise<GitIssue | null>;
+  createIssueComment(params: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+    body: string;
+    token: string;
+  }): Promise<GitIssueComment | null>;
+  updateIssueComment(params: {
+    owner: string;
+    repo: string;
+    commentId: number;
+    body: string;
+    token: string;
+    issueNumber?: number;
+  }): Promise<GitIssueComment | null>;
+  getBranch(params: {
+    owner: string;
+    repo: string;
+    branchName: string;
+    token: string;
+  }): Promise<GitBranch | null>;
+}


### PR DESCRIPTION
## Summary
- add shared GitProvider interface for issue and branch operations
- implement GitHub and GitLab adapters using the interface
- make webhook routes provider-aware and add GitLab handler

## Testing
- `yarn lint:fix --filter=@open-swe/agent --filter=@open-swe/shared`
- `yarn format --filter=@open-swe/agent --filter=@open-swe/shared`
- `yarn test --filter=@open-swe/agent --filter=@open-swe/shared`


------
https://chatgpt.com/codex/tasks/task_e_68951aa943a4832ba0424f74ac2f76c7